### PR TITLE
se actualizo leads y se personalizaron los errores glovales

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace App\Exceptions;
 
 use Illuminate\Auth\Access\AuthorizationException;
@@ -8,6 +7,51 @@ use Illuminate\Validation\ValidationException;
 use Laravel\Lumen\Exceptions\Handler as ExceptionHandler;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Throwable;
+
+// class Handler extends ExceptionHandler
+// {
+//     /**
+//      * A list of the exception types that should not be reported.
+//      *
+//      * @var array
+//      */
+//     protected $dontReport = [
+//         AuthorizationException::class,
+//         HttpException::class,
+//         ModelNotFoundException::class,
+//         ValidationException::class,
+//     ];
+
+//     /**
+//      * Report or log an exception.
+//      *
+//      * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
+//      *
+//      * @param  \Throwable  $exception
+//      * @return void
+//      *
+//      * @throws \Exception
+//      */
+//     public function report(Throwable $exception)
+//     {
+//         parent::report($exception);
+//     }
+
+//     /**
+//      * Render an exception into an HTTP response.
+//      *
+//      * @param  \Illuminate\Http\Request  $request
+//      * @param  \Throwable  $exception
+//      * @return \Illuminate\Http\Response|\Illuminate\Http\JsonResponse
+//      *
+//      * @throws \Throwable
+//      */
+//     public function render($request, Throwable $exception)
+//     {
+//         return parent::render($request, $exception);
+//     }
+
+
 
 class Handler extends ExceptionHandler
 {
@@ -49,6 +93,36 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Throwable $exception)
     {
-        return parent::render($request, $exception);
+        // Manejar errores de validación
+        if ($exception instanceof ValidationException) {
+            return response()->json([
+                'message' => 'Datos de entrada inválidos',
+                'errors' => $exception->errors()
+            ], 422);
+        }
+
+        // Manejar errores de autorización
+        if ($exception instanceof AuthorizationException) {
+            return response()->json(['message' => 'No autorizado'], 403);
+        }
+
+        // Manejar errores 404 (Not Found)
+        if ($exception instanceof ModelNotFoundException) {
+            return response()->json(['message' => 'Recurso no encontrado'], 404);
+        }
+
+        // Manejar excepciones HTTP generales
+        if ($exception instanceof HttpException) {
+            $statusCode = $exception->getStatusCode();
+            $message = $exception->getMessage() ?: 'Error HTTP';
+
+            return response()->json(['message' => $message], $statusCode);
+        }
+
+        // Manejar errores 500 (Internal Server Error)
+        return response()->json([
+            'message' => 'Ocurrió un error en el servidor. Por favor, inténtelo de nuevo más tarde.'
+        ], 500);
     }
+
 }

--- a/app/Http/Controllers/LeadController.php
+++ b/app/Http/Controllers/LeadController.php
@@ -26,7 +26,7 @@ class LeadController extends Controller
 
     public function showLeads($id)
     {
-        $leads = Lead::where('id', $id)->get();
+        $leads = Lead::where('id', $id)->first();
         return response($leads);
     }
 

--- a/app/Http/Controllers/LeadController.php
+++ b/app/Http/Controllers/LeadController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Models\Lead;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
 
 class LeadController extends Controller
 {
@@ -20,7 +21,7 @@ class LeadController extends Controller
     public function getAllLeads()
     {
         $leads = Lead::all();
-    return response()->json(["leads" => $leads]);
+        return response()->json(["leads" => $leads]);
     }
 
     public function showLeads($id)
@@ -31,20 +32,41 @@ class LeadController extends Controller
 
     public function insertLeads(Request $request)
     {
+        // valida si el campo mail existe
+        $validator = Validator::make($request->all(), [
+            'mail' => 'required|string|email|max:255',
+        ]);
+
+        // Verificar si la validación falla
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        // Verificar si el correo ya existe en la base de datos
+        $existingLead = Lead::where('mail', $request->mail)->first();
+
+        if ($existingLead) {
+            // Si el correo ya existe, retornar un mensaje de error
+            return response()->json(['message' => 'El correo ya está registrado'], 409);
+        }
+
+        // Si el correo no existe, proceder con la inserción
         $leads = new Lead();
         $leads->name = $request->name;
-        $leads->phone = $request->thone;
+        $leads->phone = $request->phone;
         $leads->mail = $request->mail;
-        $leads->state = $request->state_id;
+        $leads->state = $request->state;
         $leads->city = $request->city;
-        $leads->source = $request->sources_id;
-        $leads->interest = $request->interest_id;
+        $leads->source = $request->source;
+        $leads->interest = $request->interest;
         $leads->message = $request->message;
-        $leads->status = $request->status_id;
+        $leads->status = $request->status;
         $leads->company_id = $request->company_id;
         $leads->save();
-        return response()->json(['message' => 'Lead created successfully', 'leads' => $leads], 201);
+
+        return response()->json(['message' => 'Lead se creo exitosamente', 'lead' => $leads], 201);
     }
+
     public function deleteLeads($id)
     {
         $leads = Lead::where('id', $id)->first();
@@ -52,7 +74,7 @@ class LeadController extends Controller
             return response()->json(["error" => "Usuario no encontrado"]);
         }
         $leads->delete();
-        return response()->json(["data" => "El usuario $id se ha eliminado exitosamente"]);
+        return response()->json(["message" => "El usuario $id se ha eliminado exitosamente"]);
     }
     public function updateLeads(Request $request, $id)
     {
@@ -60,14 +82,14 @@ class LeadController extends Controller
         $leads->name = $request->name;
         $leads->phone = $request->thone;
         $leads->mail = $request->mail;
-        $leads->state = $request->state_id;
+        $leads->state = $request->state;
         $leads->city = $request->city;
-        $leads->source = $request->sources_id;
-        $leads->interest = $request->interest_id;
+        $leads->source = $request->source;
+        $leads->interest = $request->interest;
         $leads->message = $request->message;
-        $leads->status = $request->status_id;
+        $leads->status = $request->status;
         $leads->company_id = $request->company_id;
         $leads->save();
-        return response()->json(["data" => "Se actualizó correctamente"]);
+        return response()->json(["message" => "Se actualizó correctamente"]);
     }
 }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -95,6 +95,8 @@ $app->register(App\Providers\AppServiceProvider::class);
 $app->register(App\Providers\AuthServiceProvider::class);
 $app->register(App\Providers\EventServiceProvider::class);
 $app->register(Flipbox\LumenGenerator\LumenGeneratorServiceProvider::class);
+// para hacer la validacion del correo 
+$app->register(Illuminate\Validation\ValidationServiceProvider::class);
 
 /*
 |--------------------------------------------------------------------------

--- a/database/migrations/2024_06_25_082250_modify_data_the_status_of_table_lead.php
+++ b/database/migrations/2024_06_25_082250_modify_data_the_status_of_table_lead.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class ModifyDataTheStatusOfTableLead extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('lead', function (Blueprint $table) {
+            $table->integer('status')->change(); // quite el default porque estabadando errores
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('lead', function (Blueprint $table) {
+            //
+        });
+    }
+}

--- a/database/migrations/2024_06_25_082804_alter_status_column_in_leads_table.php
+++ b/database/migrations/2024_06_25_082804_alter_status_column_in_leads_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AlterStatusColumnInLeadsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('lead', function (Blueprint $table) {
+            $table->integer('status')->default(null)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('lead', function (Blueprint $table) {
+            //
+        });
+    }
+}


### PR DESCRIPTION
se actualizo el controlador leads para que a la hora de crear un nuevo usuario y el correo exista salga un error con el mensage que el correo existe 

![image](https://github.com/8devmx/estadias-api/assets/55563474/74fec6d1-fd27-4648-b72a-c5cbb9093760)

![image](https://github.com/8devmx/estadias-api/assets/55563474/15d1fb35-8b4f-425a-9643-e2092e544968)

se cambio el campo status de default 0 porque ocasionaba errores que no podía ver en el proyecto que tengo descargado

![image](https://github.com/8devmx/estadias-api/assets/55563474/c77707a1-36d7-44fe-a7fe-c655c23980dd)


se cambio los mansajes de lumen de los errores 500, 400, etc para que sean personalizados comente las lineas por si hay errores en el futuro 

![image](https://github.com/8devmx/estadias-api/assets/55563474/3e60d9a5-6ce6-476b-b2a8-9316d70d7ca6)

